### PR TITLE
revert the revert to update FastLED packages

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -177,7 +177,7 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    fastled/FastLED @ 3.6.0
+    fastled/FastLED @ 3.7.0
     IRremoteESP8266 @ 2.8.6
     makuna/NeoPixelBus @ 2.7.8
     https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
@@ -226,19 +226,15 @@ lib_deps =
   ${env.lib_deps}
 
 [esp32]
-#platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
-platform = espressif32@3.5.0
-platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
+platform = espressif32@6.7.0
+platform_packages = framework-arduinoespressif32 @ 3.20017.0
 build_flags = -g
   -D ARDUINO_ARCH_ESP32
   -D FASTLED_ALL_PINS_HARDWARE_SPI
   -D CONFIG_ASYNC_TCP_USE_WDT=0
-  #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
-  -D LOROL_LITTLEFS
-  ; -D ARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+  -D ARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 lib_deps =
-  https://github.com/lorol/LITTLEFS.git
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
 # additional build flags for audioreactive
@@ -247,8 +243,8 @@ AR_lib_deps = https://github.com/kosme/arduinoFFT @ 2.0.2
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = ${esp32.platform}
+platform_packages = ${esp32.platform_packages}
 build_flags = -g
   -D ARDUINO_ARCH_ESP32
   -D ARDUINO_ARCH_ESP32S2
@@ -267,8 +263,8 @@ lib_deps =
 
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = ${esp32.platform}
+platform_packages = ${esp32.platform_packages}
 build_flags = -g
   -D ARDUINO_ARCH_ESP32
   -D ARDUINO_ARCH_ESP32C3
@@ -286,8 +282,8 @@ lib_deps =
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = ${esp32.platform}
+platform_packages = ${esp32.platform_packages}
 build_flags = -g
   -D ESP32
   -D ARDUINO_ARCH_ESP32

--- a/platformio_tubes.ini
+++ b/platformio_tubes.ini
@@ -14,7 +14,6 @@ build_flags = -O2
   -D WLED_DISABLE_HUESYNC
   -D WLED_DISABLE_WEBSOCKETS
   -D WLED_DISABLE_ADALIGHT
-  -D WLED_DISABLE_ESPNOW
   -D IRTYPE=0
 lib_ignore =
   ESPAsyncTCP
@@ -46,6 +45,7 @@ build_unflags =
 build_flags = 
   ${tubes.build_flags}
   ${env:esp32_quinled_dig2go.build_flags} 
+  -D NUM_STRIPS=1 -D DEFAULT_LED_COUNT=150
 lib_ignore = 
   ESPAsyncTCP
   ESPAsyncUDP


### PR DESCRIPTION

The issue with ESPnow syncing was causes because I disabled it in the Tubes build when I was trying to get the new version of the ESPnow library working with the code base.  I mistakenly didn't realized that the Tubes plugin used the based ESPnow libraries as well.

Removing [this line](https://github.com/SteveEisner/WLEDtubes/compare/main...craiglink:WLEDtubes:package-update?expand=1#diff-49762cf73835abd445da15e227abd761ab31362b9b456e02a2c2fafb03519f21L17) fixes syncing while still having the new libraries

I also added a default to the env:esp32_quinled_dig2go_tube build to support 150 LEDs