### PR TITLE
standarize platformio with make repo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,9 +47,8 @@ default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_1
 src_dir  = ./wled00
 data_dir = ./wled00/data
 build_cache_dir = ~/.buildcache
-extra_configs = 
+extra_configs =
   platformio_override.ini
-  ;platformio_tubes.ini
 
 [common]
 # ------------------------------------------------------------------------------
@@ -143,6 +142,7 @@ build_unflags =
 
 build_flags_esp8266 = ${common.build_flags}  ${esp8266.build_flags}
 build_flags_esp32   = ${common.build_flags}  ${esp32.build_flags}
+build_flags_esp32_V4= ${common.build_flags}  ${esp32_idf_V4.build_flags}
 
 ldscript_1m128k = eagle.flash.1m128.ld
 ldscript_2m512k = eagle.flash.2m512.ld
@@ -177,9 +177,9 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    fastled/FastLED @ 3.7.0
-    IRremoteESP8266 @ 2.8.6
-    makuna/NeoPixelBus @ 2.7.8
+    fastled/FastLED @ 3.6.0
+    IRremoteESP8266 @ 2.8.2
+    makuna/NeoPixelBus @ 2.7.5
     https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
@@ -221,39 +221,62 @@ build_flags =
   ; -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED ;; (experimental) adds some extra heap, but may cause slowdown
 
 lib_deps =
+  #https://github.com/lorol/LITTLEFS.git
   ESPAsyncTCP @ 1.2.2
   ESPAsyncUDP
   ${env.lib_deps}
 
 [esp32]
-platform = espressif32@6.7.0
-platform_packages = framework-arduinoespressif32 @ 3.20017.0
+#platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
+platform = espressif32@3.5.0
+platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
 build_flags = -g
-  -D ARDUINO_ARCH_ESP32
-  -D FASTLED_ALL_PINS_HARDWARE_SPI
+  -DARDUINO_ARCH_ESP32
+  #-DCONFIG_LITTLEFS_FOR_IDF_3_2
   -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D ARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
+  #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
+  -D LOROL_LITTLEFS
+  ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 lib_deps =
+  https://github.com/lorol/LITTLEFS.git
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
 # additional build flags for audioreactive
 AR_build_flags = -D USERMOD_AUDIOREACTIVE -D UM_AUDIOREACTIVE_USE_NEW_FFT
-AR_lib_deps = https://github.com/kosme/arduinoFFT @ 2.0.2
+AR_lib_deps = https://github.com/kosme/arduinoFFT#419d7b0
+
+[esp32_idf_V4]
+;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
+;; very similar to the normal ESP32 flags, but omitting Lorol LittleFS, as littlefs is included in the new framework already.
+;;
+;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
+;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
+platform = espressif32@5.3.0
+platform_packages =
+build_flags = -g
+  -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
+  -DARDUINO_ARCH_ESP32 -DESP32
+  #-DCONFIG_LITTLEFS_FOR_IDF_3_2
+  -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
+default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+lib_deps =
+  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
+  ${env.lib_deps}
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
+platform = espressif32@5.3.0
+platform_packages =
 build_flags = -g
-  -D ARDUINO_ARCH_ESP32
-  -D ARDUINO_ARCH_ESP32S2
-  -D FASTLED_ALL_PINS_HARDWARE_SPI
-  -D FASTLED_ESP32_SPI_BUS=FSPI
-  -D CONFIG_IDF_TARGET_ESP32S2=1
+  -DARDUINO_ARCH_ESP32
+  -DARDUINO_ARCH_ESP32S2
+  -DCONFIG_IDF_TARGET_ESP32S2=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D ARDUINO_USB_MSC_ON_BOOT=0 -D ARDUINO_USB_DFU_ON_BOOT=0
-  -D ARDUINO_USB_MODE=0 ;; this flag is mandatory for ESP32-S2 !
+  -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0
+  -DCO
+  -DARDUINO_USB_MODE=0 ;; this flag is mandatory for ESP32-S2 !
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_CDC_ON_BOOT
 
@@ -263,16 +286,15 @@ lib_deps =
 
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
+platform = espressif32@5.3.0
+platform_packages =
 build_flags = -g
-  -D ARDUINO_ARCH_ESP32
-  -D ARDUINO_ARCH_ESP32C3
-  -D FASTLED_ALL_PINS_HARDWARE_SPI
-  -D FASTLED_ESP32_SPI_BUS=HSPI
-  -D CONFIG_IDF_TARGET_ESP32C3=1
+  -DARDUINO_ARCH_ESP32
+  -DARDUINO_ARCH_ESP32C3
+  -DCONFIG_IDF_TARGET_ESP32C3=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D ARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
+  -DCO
+  -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_CDC_ON_BOOT
 
@@ -282,16 +304,16 @@ lib_deps =
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
+platform = espressif32@5.3.0
+platform_packages =
 build_flags = -g
-  -D ESP32
-  -D ARDUINO_ARCH_ESP32
-  -D ARDUINO_ARCH_ESP32S3
-  -D FASTLED_ALL_PINS_HARDWARE_SPI
-  -D CONFIG_IDF_TARGET_ESP32S3=1
+  -DESP32
+  -DARDUINO_ARCH_ESP32
+  -DARDUINO_ARCH_ESP32S3
+  -DCONFIG_IDF_TARGET_ESP32S3=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D ARDUINO_USB_MSC_ON_BOOT=0 -D ARDUINO_DFU_ON_BOOT=0
+  -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_DFU_ON_BOOT=0
+  -DCO
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_MODE, ARDUINO_USB_CDC_ON_BOOT
 
@@ -414,10 +436,9 @@ board_build.partitions = ${esp32.default_partitions}
 [env:esp32_quinled_diguno]
 extends = env:esp32dev
 build_flags = ${env:esp32dev.build_flags} -D RLYPIN=12 -D BTNPIN=0 -D DATA_PINS=16 -D DMTYPE=1 -D I2S_SDPIN=19 -D I2S_WSPIN=4 -D I2S_CKPIN=18
-  -D FASTLED_ESP32_SPI_BUS=HSPI
-  ${esp32.AR_build_flags}
+  -D USERMOD_AUDIOREACTIVE
 lib_deps = ${env:esp32dev.lib_deps}
-  ${esp32.AR_lib_deps}
+  https://github.com/blazoncek/arduinoFFT.git
 upload_speed = 690000
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
@@ -433,6 +454,21 @@ monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
+
+[env:esp32dev_V4_dio80]
+;; experimental ESP32 env using ESP-IDF V4.4.x
+;; Warning: this build environment is not stable!!
+;; please erase your device before installing.
+board = esp32dev
+platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32_idf_V4.platform_packages}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags}  ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=ESP32_V4_qio80 #-D WLED_DISABLE_BROWNOUT_DET
+lib_deps = ${esp32_idf_V4.lib_deps}
+monitor_filters = esp32_exception_decoder
+board_build.partitions = ${esp32_idf_V4.default_partitions}
+board_build.f_flash = 80000000L
+board_build.flash_mode = dio
 
 [env:esp32_eth]
 board = esp32-poe
@@ -483,7 +519,7 @@ platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600 ; or  460800
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB
-  -D WLED_WATCHDOG_TIMEOUT=0
+  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   ;-D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1 ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   ;-D WLED_DEBUG
@@ -503,7 +539,7 @@ platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags}
-  -D WLED_WATCHDOG_TIMEOUT=0
+  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   ; -D WLED_RELEASE_NAME=ESP32-S3_PSRAM
@@ -802,27 +838,3 @@ lib_deps =
   ${esp32.lib_deps}
   TFT_eSPI @ ^2.3.70
 board_build.partitions = ${esp32.default_partitions}
-
-# ------------------------------------------------------------------------------
-# ESP32 S3 Matrix M1
-# ------------------------------------------------------------------------------
-[env:esp32-s3-matrix-m1]
-extends = env:esp32s3dev_8MB_PSRAM_opi
-board_build.arduino.memory_type = qio_qspi ;; use with PSRAM: 2MB or  4MB
-board_upload.flash_size = 4MB
-board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=esp32-s3-matrix-m1
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D WLED_WATCHDOG_TIMEOUT=0
-  -D ARDUINO_USB_CDC_ON_BOOT=1
-  -D ARDUINO_USB_MODE=1
-  ;-D WLED_USE_PSRAM
-  -D BOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
-  -D IRTYPE=0
-  -D WLED_DISABLE_INFRARED
-  -D ABL_MILLIAMPS_DEFAULT=250
-  -D FASTLED_ALL_PINS_HARDWARE_SPI
-  -D NUM_STRIPS=1 -D PIXEL_COUNTS=64 -D DEFAULT_LED_COUNT=64
-  -D DEFAULT_LED_COLOR_ORDER=1 -D LEDPIN=14
-lib_deps = ${esp32s3.lib_deps}
-lib_ignore = IRremoteESP8266

--- a/platformio_tubes.ini
+++ b/platformio_tubes.ini
@@ -10,14 +10,15 @@ platform = espressif32@6.7.0
 platform_packages = framework-arduinoespressif32 @ 3.20017.0
 build_unflags =
   -D LOROL_LITTLEFS
+  -D CONFIG_ASYNC_TCP_USE_WDT
 build_flags =
   -g
   -O2
   -D FASTLED_ALL_PINS_HARDWARE_SPI
   -D ARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D WLED_WATCHDOG_TIMEOUT=0
   -D USERMOD_TUBES
+  -D CONFIG_ASYNC_TCP_RUNNING_CORE=-1
   ; Disable a bunch of unnecessary integrations
   -D WLED_DISABLE_BLYNK
   -D WLED_DISABLE_MQTT
@@ -74,11 +75,11 @@ build_flags =
   -D FASTLED_ESP32_SPI_BUS=HSPI
   -D NUM_STRIPS=1 -D DEFAULT_LED_COUNT=150
 lib_ignore = 
-  ${tubes.lib_ignore}
+  ESPAsyncTCP
+  ESPAsyncUDP
   ${env:esp32_quinled_dig2go.lib_ignore}
 lib_deps = 
   ${tubes.lib_deps}
-  IRremoteESP8266 @ 2.8.6
 
 
 
@@ -104,7 +105,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   -D NUM_STRIPS=1 -D PIXEL_COUNTS=64 -D DEFAULT_LED_COUNT=64
   -D DEFAULT_LED_COLOR_ORDER=1 -D LEDPIN=14
 lib_deps = ${esp32s3.lib_deps}
-;lib_ignore = IRremoteESP8266
+lib_ignore = ${env:esp32s3dev_8MB_PSRAM_opi.lib_ignore}
+  IRremoteESP8266
 
 [env:esp32-s3-matrix-m1_tubes]
 extends = env:esp32-s3-matrix-m1
@@ -113,7 +115,6 @@ platform_packages = ${tubes.platform_packages}
 board_build.partitions = tools/WLED_ESP32_4MB_noOTA.csv
 build_unflags = ${env:esp32-s3-matrix-m1.build_unflags}
   ${tubes_no_mic.build_unflags}
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
 build_flags =
   ${tubes_no_mic.build_flags}
   ${env:esp32-s3-matrix-m1.build_flags} 

--- a/platformio_tubes.ini
+++ b/platformio_tubes.ini
@@ -1,9 +1,23 @@
 [tubes_no_mic]
-build_flags = -O2
+; these settings create a basic template for tubes build from
+; from which all other tube envs should build
+; the base build does not support
+; --  mic (audio reactive)
+; -- ir remotes
+; For devices with those inputs use the [tubes] settings
+; which adds those back in
+platform = espressif32@6.7.0
+platform_packages = framework-arduinoespressif32 @ 3.20017.0
+build_unflags =
+  -D LOROL_LITTLEFS
+build_flags =
+  -g
+  -O2
+  -D FASTLED_ALL_PINS_HARDWARE_SPI
+  -D ARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D WLED_WATCHDOG_TIMEOUT=0
   -D USERMOD_TUBES
-  ;-D USERMOD_TUBES_DISABLE_ESPNOW
   ; Disable a bunch of unnecessary integrations
   -D WLED_DISABLE_BLYNK
   -D WLED_DISABLE_MQTT
@@ -14,43 +28,100 @@ build_flags = -O2
   -D WLED_DISABLE_HUESYNC
   -D WLED_DISABLE_WEBSOCKETS
   -D WLED_DISABLE_ADALIGHT
+  -D WLED_DISABLE_ESPNOW
   -D IRTYPE=0
 lib_ignore =
   ESPAsyncTCP
   ESPAsyncUDP
   IRremoteESP8266
 lib_deps = 
+  fastled/FastLED @ ^3.7.0
+  makuna/NeoPixelBus @ ^2.7.8
+  https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
   gmag11/QuickEspNow @ ^0.6.2
   gmag11/QuickDebug @ ^0.7.0
 
 [tubes]
 extends = tubes_no_mic
-build_flags = ${tubes_no_mic.build_flags}
-  ${esp32.AR_build_flags}  
+build_flags =
+  ${tubes_no_mic.build_flags}
+  ${esp32.AR_build_flags}
 lib_deps = ${tubes_no_mic.lib_deps}
-  ${esp32.AR_lib_deps}
+  IRremoteESP8266 @ ^2.8.6
+  https://github.com/kosme/arduinoFFT @ 2.0.2 ; ${esp32.AR_LIB_deps}
+
 
 [env:esp32_quinled_dig2go]
+; basis quinled dig2go without any tubes support
 extends = env:esp32_quinled_diguno
-lib_ignore = 
-  ${env:esp32_quinled_diguno.lib_ignore}
+build_unflags = ${env:esp32_quinled_diguno.build_unflags}
+  -D WLED_DISABLE_INFRARED
+  -D IRTYPE
+lib_ignore = ${env:esp32_quinled_diguno.lib_ignore}
 lib_deps = ${env:esp32_quinled_diguno.lib_deps}
   IRremoteESP8266 @ 2.8.6
 
 [env:esp32_quinled_dig2go_tubes]
 extends = env:esp32_quinled_dig2go
+platform = ${tubes.platform}
+platform_packages = ${tubes.platform_packages}
 build_unflags = 
-  -D WLED_DISABLE_INFRARED
-  -D IRTYPE=0
+  ${tubes.build_unflags}
+  ${env:esp32_quinled_dig2go}
 build_flags = 
   ${tubes.build_flags}
   ${env:esp32_quinled_dig2go.build_flags} 
+  -D FASTLED_ESP32_SPI_BUS=HSPI
   -D NUM_STRIPS=1 -D DEFAULT_LED_COUNT=150
 lib_ignore = 
-  ESPAsyncTCP
-  ESPAsyncUDP
+  ${tubes.lib_ignore}
+  ${env:esp32_quinled_dig2go.lib_ignore}
 lib_deps = 
   ${tubes.lib_deps}
-  ${env:esp32_quinled_dig2go.lib_deps} 
+  IRremoteESP8266 @ 2.8.6
 
+
+
+# ------------------------------------------------------------------------------
+# ESP32 S3 Matrix M1
+# ------------------------------------------------------------------------------
+[env:esp32-s3-matrix-m1]
+; builds using the default WLED settings
+extends = env:esp32s3dev_8MB_PSRAM_opi
+board_build.arduino.memory_type = qio_qspi ;; use with PSRAM: 2MB or  4MB
+board_upload.flash_size = 4MB
+board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+build_unflags = ${env:esp32s3dev_8MB_PSRAM_opi.build_unflags} 
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MSC_ON_BOOT=0 
+  -D ARDUINO_DFU_ON_BOOT=0
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=esp32-s3-matrix-m1
+  -D WLED_WATCHDOG_TIMEOUT=0
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=1
+  -D BOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
+  -D ABL_MILLIAMPS_DEFAULT=250
+  -D NUM_STRIPS=1 -D PIXEL_COUNTS=64 -D DEFAULT_LED_COUNT=64
+  -D DEFAULT_LED_COLOR_ORDER=1 -D LEDPIN=14
+lib_deps = ${esp32s3.lib_deps}
+;lib_ignore = IRremoteESP8266
+
+[env:esp32-s3-matrix-m1_tubes]
+extends = env:esp32-s3-matrix-m1
+platform = ${tubes.platform}
+platform_packages = ${tubes.platform_packages}
+board_build.partitions = tools/WLED_ESP32_4MB_noOTA.csv
+build_unflags = ${env:esp32-s3-matrix-m1.build_unflags}
+  ${tubes_no_mic.build_unflags}
+  -D CONFIG_ASYNC_TCP_USE_WDT=0
+build_flags =
+  ${tubes_no_mic.build_flags}
+  ${env:esp32-s3-matrix-m1.build_flags} 
+  -D IRTYPE=0
+  -D FASTLED_ALL_PINS_HARDWARE_SPI
+lib_ignore = 
+  ${tubes_no_mic.lib_ignore}
+  ${env:esp32-s3-matrix-m1.lib_ignore} 
+lib_deps = 
+  ${tubes_no_mic.lib_deps}
 


### PR DESCRIPTION
- reverts platformio.ini to be closer to main branch ini and package version
- standardize tube builds on framework v6.7.0 / 3.20017.0 via platformio_tubes.ini
