### PR TITLE
re-enable serial input

### DIFF
--- a/platformio_tubes.ini
+++ b/platformio_tubes.ini
@@ -7,7 +7,8 @@
 ; For devices with those inputs use the [tubes] settings
 ; which adds those back in
 platform = espressif32@6.8.1
-platform_packages = ;framework-arduinoespressif32 @ 3.20017.0
+platform_packages = framework-arduinoespressif32 @ 3.20014.231204
+;platform_packages = ;framework-arduinoespressif32 @ 3.20017.0
 build_unflags =
   -D LOROL_LITTLEFS
   -D CONFIG_ASYNC_TCP_USE_WDT
@@ -30,6 +31,7 @@ build_flags =
   -D WLED_DISABLE_WEBSOCKETS
   -D WLED_DISABLE_ADALIGHT
   -D WLED_DISABLE_ESPNOW
+  -D WLED_DISABLE_SERIAL
   -D IRTYPE=0
 lib_ignore =
   ESPAsyncTCP

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -58,7 +58,9 @@ void WLED::loop()
   #ifndef WLED_DISABLE_ESPNOW
   handleRemote();
   #endif
+  #ifndef WLED_DISABLE_SERIAL
   handleSerial();
+  #endif
   handleImprovWifiScan();
   handleNotifications();
   handleTransitions();


### PR DESCRIPTION
accidently disabled by merge - [https://github.com/Aircoookie/WLED/commit/d03ad1f01c6b428dc3eb5674a8aa1dbf2bc7cdeb](https://github.com/Aircoookie/WLED/commit/d03ad1f01c6b428dc3eb5674a8aa1dbf2bc7cdeb) 

changed to be an #ifdef instead of adding the `return;`

also current version of Espressif Ardunio SDK seems to break Serial input as well so rolling back to 2.0.14 . There were definitely some bugs introduces in 2.0.15, and it appears they did not get them fully rolled back in 2.0.16+